### PR TITLE
Add config options for game pausing on popups

### DIFF
--- a/SoundTheAlarm/STAAction.cs
+++ b/SoundTheAlarm/STAAction.cs
@@ -35,7 +35,7 @@ namespace SoundTheAlarm {
                             ;
 
                             settlementToTrack = v.Settlement;
-                            InformationManager.ShowInquiry(new InquiryData("Sound The Alarm", display, true, true, "Track", "Close", new Action(Track), null, ""), true);
+                            InformationManager.ShowInquiry(new InquiryData("Sound The Alarm", display, true, true, "Track", "Close", new Action(Track), null, ""), STALibrary.Instance.STAConfiguration.PauseOnFiefPopup);
                             if (STALibrary.Instance.STAConfiguration.EnableDebugMessages)
                                 InformationManager.DisplayMessage(new InformationMessage("STALibrary: " + display, new Color(1.0f, 0.0f, 0.0f)));
                         }
@@ -69,7 +69,7 @@ namespace SoundTheAlarm {
                                 "!"
                             ;
                             settlementToTrack = e.BesiegedSettlement;
-                            InformationManager.ShowInquiry(new InquiryData("Sound The Alarm", display, true, true, "Track", "Close", new Action(Track), null, ""), true);
+                            InformationManager.ShowInquiry(new InquiryData("Sound The Alarm", display, true, true, "Track", "Close", new Action(Track), null, ""), STALibrary.Instance.STAConfiguration.PauseOnFiefPopup);
                             if (STALibrary.Instance.STAConfiguration.EnableDebugMessages)
                                 InformationManager.DisplayMessage(new InformationMessage("STALibrary: " + display, new Color(1.0f, 0.0f, 0.0f)));
                         }
@@ -96,7 +96,7 @@ namespace SoundTheAlarm {
                 " has signed a declaration of war against the " +
                 faction2.Name.ToString();
             ;
-            InformationManager.ShowInquiry(new InquiryData("Sound The Alarm", display, true, false, "Ok", "Close", null, null, ""), false);
+            InformationManager.ShowInquiry(new InquiryData("Sound The Alarm", display, true, false, "Ok", "Close", null, null, ""), STALibrary.Instance.STAConfiguration.PauseOnWarPeacePopup);
             if (STALibrary.Instance.STAConfiguration.EnableDebugMessages)
                 InformationManager.DisplayMessage(new InformationMessage("STALibrary: " + display, new Color(1.0f, 0.0f, 0.0f)));
         }
@@ -110,7 +110,7 @@ namespace SoundTheAlarm {
                 " has signed a declaration of peace with the " +
                 faction2.Name.ToString();
             ;
-            InformationManager.ShowInquiry(new InquiryData("Sound The Alarm", display, true, false, "Ok", "Close", null, null, ""), false);
+            InformationManager.ShowInquiry(new InquiryData("Sound The Alarm", display, true, false, "Ok", "Close", null, null, ""), STALibrary.Instance.STAConfiguration.PauseOnWarPeacePopup);
             if (STALibrary.Instance.STAConfiguration.EnableDebugMessages)
                 InformationManager.DisplayMessage(new InformationMessage("STALibrary: " + display, new Color(1.0f, 0.0f, 0.0f)));
         }

--- a/SoundTheAlarm/STAConfiguration.cs
+++ b/SoundTheAlarm/STAConfiguration.cs
@@ -8,8 +8,10 @@ namespace SoundTheAlarm {
     public class STAConfiguration {
 
         public bool EnableFiefPopup { get; set; } = true;
+        public bool PauseOnFiefPopup { get; set; } = true;
         public bool EnableWarPopup { get; set; } = true;
         public bool EnablePeacePopup { get; set; } = true;
+        public bool PauseOnWarPeacePopup { get; set; } = false;
         public bool EnableDebugMessages { get; set; } = false;
 
     }

--- a/SoundTheAlarm/STALibrary.cs
+++ b/SoundTheAlarm/STALibrary.cs
@@ -28,11 +28,17 @@ namespace SoundTheAlarm {
                         case "enablefiefpopup":
                             STAConfiguration.EnableFiefPopup = node.InnerText.ToBool();
                             break;
+                        case "pauseonfiefpopup":
+                            STAConfiguration.PauseOnFiefPopup = node.InnerText.ToBool();
+                            break;
                         case "enablewarpopup":
                             STAConfiguration.EnableWarPopup = node.InnerText.ToBool();
                             break;
                         case "enablepeacepopup":
                             STAConfiguration.EnablePeacePopup = node.InnerText.ToBool();
+                            break;
+                        case "pauseonwarpeacepopup":
+                            STAConfiguration.PauseOnWarPeacePopup = node.InnerText.ToBool();
                             break;
                         case "enabledebugmessages":
                             STAConfiguration.EnableDebugMessages = node.InnerText.ToBool();


### PR DESCRIPTION
adds PauseOnFiefPopup and PauseOnWarPeacePopup

the config xml might be changed like the following, which has as it's defaults the previous hardcoded values:

adding the entries:

```
    <!-- Whether to pause on fief attacked popup -->
    <PauseOnFiefPopup>true</PauseOnFiefPopup>
```

and

```
    <!-- Whether to pause on war and peace popups -->
    <PauseOnWarPeacePopup>false</PauseOnWarPeacePopup>
```
